### PR TITLE
Update OpenNI2 from occipital/OpenNI2.

### DIFF
--- a/OpenNI2/Makefile
+++ b/OpenNI2/Makefile
@@ -12,6 +12,7 @@
 #   make FORCE_BUILD_CLR=1
 #
 #############################################################################
+export ALLOW_WARNINGS = 1
 
 include ThirdParty/PSCommon/BuildSystem/CommonDefs.mak
 

--- a/OpenNI2/README.md
+++ b/OpenNI2/README.md
@@ -1,7 +1,158 @@
-# This repository is no longer maintained.
+# OpenNI
 
-Issue reports and pull requests will not be attended.
-There are volunteers who are now maintaining OpenNI such as listed below, so please work with them.
 
-* Occipital: http://structure.io/openni [[Fork on Github](https://github.com/occipital/openni2)]
+Website: http://structure.io/openni
 
+## Building Prerequisites
+
+### Windows
+
+- Microsoft Visual Studio 2010
+
+    - Download and install from: http://msdn.microsoft.com/en-us/vstudio/bb984878.aspx
+
+- Microsoft Kinect SDK v1.6
+
+    - Download and install from: http://go.microsoft.com/fwlink/?LinkID=262831
+
+- Python 2.6+/3.x
+
+    - Download and install from: http://www.python.org/download/
+
+- PyWin32
+
+    - Download and install from: http://sourceforge.net/projects/pywin32/files/pywin32/
+    
+    Please make sure you download the version that matches your exact python version.
+
+- JDK 6.0
+
+    - Download and install from: http://www.oracle.com/technetwork/java/javase/downloads/jdk-6u32-downloads-1594644.html
+    
+    You must also define an environment variable called `JAVA_HOME` that points to the JDK installation directory. For example:
+
+    	set JAVA_HOME=c:\Program Files (x86)\Java\jdk1.6.0_32
+
+- WIX 3.5
+
+    - Download and install from: http://wix.codeplex.com/releases/view/60102
+
+- Doxygen
+
+    - Download and install from: http://www.stack.nl/~dimitri/doxygen/download.html#latestsrc
+
+- GraphViz
+
+    - Download and install from: http://www.graphviz.org/Download_windows.php
+
+### Linux
+
+- GCC 4.x
+
+	- Download and install from: http://gcc.gnu.org/releases.html
+
+    - Or use `apt`:
+    	
+	    	sudo apt-get install g++
+
+- Python 2.6+/3.x
+
+    - Download and install from: http://www.python.org/download/
+
+    - Or use `apt`:
+
+	    	sudo apt-get install python
+
+- LibUSB 1.0.x
+
+    - Download and install from: http://sourceforge.net/projects/libusb/files/libusb-1.0/
+
+    - Or use `apt`:
+
+	    	sudo apt-get install libusb-1.0-0-dev
+
+- LibUDEV
+
+		sudo apt-get install libudev-dev
+
+- JDK 6.0
+
+    - Download and install from: http://www.oracle.com/technetwork/java/javase/downloads/jdk-6u32-downloads-1594644.html
+
+    - Or use `apt`:
+    
+    	- On Ubuntu 10.x:
+
+				sudo add-apt-repository "deb http://archive.canonical.com/ lucid partner"
+				sudo apt-get update
+				sudo apt-get install sun-java6-jdk
+
+    	- On Ubuntu 12.x:
+
+				sudo apt-get install openjdk-6-jdk
+
+- FreeGLUT3
+
+    - Download and install from: http://freeglut.sourceforge.net/index.php#download
+
+    - Or use `apt`:
+
+	    	sudo apt-get install freeglut3-dev
+
+- Doxygen
+
+    - Download and install from: http://www.stack.nl/~dimitri/doxygen/download.html#latestsrc
+
+    - Or use `apt`:
+    
+    		sudo apt-get install doxygen
+
+- GraphViz
+
+    - Download and install from: http://www.graphviz.org/Download_linux_ubuntu.php
+
+    - Or use `apt`:
+    
+    		sudo apt-get install graphviz
+
+### Android
+
+- Download and install the Android NDK version **r8d**. Newer versions will **NOT** work.
+
+- For Mac OS X: http://dl.google.com/android/ndk/android-ndk-r8d-darwin-x86.tar.bz2
+- For Windows:  http://dl.google.com/android/ndk/android-ndk-r8d-windows.zip
+- For Linux:    http://dl.google.com/android/ndk/android-ndk-r8d-linux-x86.tar.bz2
+
+    Building Android packages requires the NDK_ROOT environment variable to be defined, and its value must be pointing to the NDK installation dir: `NDK_ROOT=/path/to/android-ndk-r8d`
+
+## Building
+
+### Building on Windows:
+
+  Open the solution `OpenNI.sln`
+
+### Building on Linux:
+
+  Run:
+
+	make
+
+### Cross-Compiling for ARM on Linux
+
+  The following environment variables should be defined:
+
+- `ARM_CXX=path-to-cross-compilation-g++`
+- `ARM_STAGING=path-to-cross-compilation-staging-dir`
+
+Then, run:
+
+	PLATFORM=Arm make
+
+### Creating OpenNI2 packages
+
+  - Go into the directory `Packaging`
+  - Run:
+
+		ReleaseVersion.py [x86|x64|arm|android]
+
+  - The installer will be placed in the `Final` directory

--- a/OpenNI2/Source/Tools/NiViewer/Makefile
+++ b/OpenNI2/Source/Tools/NiViewer/Makefile
@@ -26,7 +26,7 @@ else
 endif
 
 LIB_DIRS  += ../../../ThirdParty/PSCommon/XnLib/Bin/$(PLATFORM)-$(CFG)
-USED_LIBS += OpenNI2 XnLib
+USED_LIBS += OpenNI2 XnLib pthread
 
 EXE_NAME = NiViewer
 

--- a/OpenNI2/ThirdParty/GL/glh/glh_convenience.h
+++ b/OpenNI2/ThirdParty/GL/glh/glh_convenience.h
@@ -47,12 +47,6 @@
 // with opengl...
 
 
-
-// debugging hack...
-#include <iostream>
-
-using namespace std;
-
 #ifdef MACOS
 #include <OpenGL/gl.h>
 #else

--- a/OpenNI2/ThirdParty/PSCommon/XnLib/ThirdParty/GL/glh/glh_convenience.h
+++ b/OpenNI2/ThirdParty/PSCommon/XnLib/ThirdParty/GL/glh/glh_convenience.h
@@ -46,13 +46,6 @@
 // Convenience methods for using glh_linear objects
 // with opengl...
 
-
-
-// debugging hack...
-#include <iostream>
-
-using namespace std;
-
 #ifdef MACOS
 #include <OpenGL/gl.h>
 #else


### PR DESCRIPTION
This pulls in the latest version of OpenNI2 from https://github.com/occipital/OpenNI2, solving issue #14.

@RaresAmbrus if you are ok with this then please merge so that I can make an indigo release. If you have a better way of including the upstream OpenNI changes then that would be nice.
