### PR TITLE
Using the depth sw registration (this should fix the simulation image nodes)

### DIFF
--- a/launch/processing.launch
+++ b/launch/processing.launch
@@ -66,7 +66,7 @@
         respawn="$(arg respawn)">
 	<remap from="rgb/camera_info" to="$(arg rgb_camera_info)"/>
   	<remap from="rgb/image_rect_color" to="$(arg camera)/rgb/image_rect_color"/>    
-        <remap from="depth_registered/image_rect" to="$(arg camera)/depth/image_rect"/>    
+        <remap from="depth_registered/image_rect" to="$(arg camera)/depth_registered/image_rect"/>    
         <remap from="depth_registered/points" to="$(arg camera)/depth_registered/points"/>    
   </node>
 


### PR DESCRIPTION
This does not affect the point clouds generated when using the actual camera. (we're using hw registration which already publishes the images in the same frame, hence sw registration will not do anything). 
